### PR TITLE
Fix incorrect config of scm section in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,10 @@ limitations under the License.
   </developers>
 
   <scm>
-    <connection>scm:git:git://gerrit.ovirt.org/ovirt-engine-sdk.git</connection>
-    <developerConnection>scm:git:git://gerrit.ovirt.org/ovirt-engine-sdk.git</developerConnection>
-    <url>git://gerrit.ovirt.org/ovirt-engine-sdk.git</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/oVirt/ovirt-engine-sdk-go.git</connection>
+    <developerConnection>scm:git:git://github.com/oVirt/ovirt-engine-sdk-go.git</developerConnection>
+    <url>git://github.com/oVirt/ovirt-engine-sdk-go.git</url>
+    <tag>4.3.1</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
### Description of the Change

The original configuration in the `scm` section of the root `pom.xml` was *borrowed* from the official Python sdk project. This PR will fix the incorrect address of git repo.


Signed-off-by: imjoey <majunjiev@gmail.com>