### PR TITLE
automation: add fc29 jobs

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,4 +1,5 @@
 distros:
+  - fc29
   - fc28
   - el7
 release_branches:

--- a/automation/build-artifacts.repos
+++ b/automation/build-artifacts.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/build-artifacts.repos.el7
+++ b/automation/build-artifacts.repos.el7
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/build.repos
+++ b/automation/build.repos
@@ -1,1 +1,0 @@
-epel-el7,https://dl.fedoraproject.org/pub/epel/7/x86_64/

--- a/automation/check-merged.repos
+++ b/automation/check-merged.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/check-merged.repos.el7
+++ b/automation/check-merged.repos.el7
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/check-patch.repos
+++ b/automation/check-patch.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/check-patch.repos.el7
+++ b/automation/check-patch.repos.el7
@@ -1,1 +1,0 @@
-build.repos

--- a/packaging/spec.fc29.in
+++ b/packaging/spec.fc29.in
@@ -1,0 +1,73 @@
+# Deal with "Empty %files file {buildroot}/ovirt-engine-sdk-go/debugsourcefiles.list"
+%undefine _debugsource_packages
+%undefine _debuginfo_subpackages
+
+# Deal with "Empty %files file {buildroot}/ovirt-engine-sdk-go/debugfiles.list"
+%global debug_package %{nil}
+
+%global tar_version   4.3.0
+%global import_path   github.com/ovirt/go-ovirt
+%global gopath        %{_datadir}/gocode
+%global build_gopath  %{buildroot}/%{gopath}
+
+Name: go-ovirt-engine-sdk4
+Summary: Go SDK for version 4 of the oVirt Engine API
+Version: %{tar_version}
+Release: 1%{?dist}
+License: ASL 2.0
+URL: http://godoc.org/%{import_path}
+Source: ovirt-engine-sdk-go-%{tar_version}.tar.gz
+
+BuildRequires: golang
+BuildRequires: golang-github-stretchr-testify-devel
+
+
+%description
+This package contains the Go SDK for version 4 of the oVirt Engine API.
+
+
+%package devel
+BuildRequires:  golang
+Requires:       golang
+Summary:        Go SDK for version 4 of the oVirt Engine API
+Provides:       golang(%{import_path}) = %{version}-%{release}
+
+%description devel
+This package contains the Go SDK for version 4 of the oVirt Engine API.
+
+
+%prep
+%setup -q -n ovirt-engine-sdk-go-%{tar_version}
+# many golang binaries are "vendoring" (bundling) sources, so remove them.
+# Those dependencies need to be packaged independently.
+rm -rf vendor
+
+
+%build
+
+
+%install
+install -d %{build_gopath}/src/%{import_path}
+cp -av *.go %{build_gopath}/src/%{import_path}
+
+
+%check
+export GOPATH=%{build_gopath}
+go get -u github.com/stretchr/testify/assert
+go test -v ./
+rm -fr %{build_gopath}/src/github.com/stretchr
+rm -fr %{build_gopath}/pkg/*
+
+
+%files devel
+%doc README.md examples
+%license LICENSE.txt
+%dir %{gopath}/src/%{import_path}
+%{gopath}/src/%{import_path}/*.go
+
+
+%changelog
+* Tue Jan 29 2019 Joey Ma <majunjiev@gmail.com> - 4.3.0-1
+- Update model to 4.3.20
+- Use semantic versioning to manage the dependency of this sdk
+- Add support for oVirt CI System integration


### PR DESCRIPTION
### Description of the Change

Add fc29 jobs to automation

### Alternate Designs

get builds done somewhere else

### Benefits

Test the packaging on fc29 and get fc29 builds on official releases

### Possible Drawbacks

May need some source code adjustment within the project if test will fail on fc29 build

### Verification Process

CI will handle.
