### PR TITLE
Add the `v` prefix for tags of go-ovirt

### DIFF
--- a/automation/deploy-to-go-ovirt.sh
+++ b/automation/deploy-to-go-ovirt.sh
@@ -70,8 +70,8 @@ function _deploy_to_master() {
 
 function _deploy_to_tag() {
     pushd go-ovirt
-    git tag -a $TRAVIS_TAG -m "New version release: $TRAVIS_TAG"
-    git push origin $TRAVIS_TAG
+    git tag -a v$TRAVIS_TAG -m "New version release: v$TRAVIS_TAG"
+    git push origin v$TRAVIS_TAG
     popd
 }
 


### PR DESCRIPTION
Current tag for `go-ovirt` is not starting with a `v` prefix, which would be regarded as a pseudo-version instead of a stable one. This pr added the missing `v` prefix when tagging `go-ovirt`.

Signed-off-by: imjoey <majunjiev@gmail.com>
