### PR TITLE
Add go mod to manage the package dependencies

### DIFF
--- a/automation/deploy-to-go-ovirt.sh
+++ b/automation/deploy-to-go-ovirt.sh
@@ -50,13 +50,15 @@ function _clone_remote_master() {
 
 function _deploy_to_master() {
     # Remove the original files
-    rm -fr go-ovirt/*.go go-ovirt/README.md go-ovirt/examples
+    rm -fr go-ovirt/*.go go-ovirt/README.md go-ovirt/examples go-ovirt/vendor
 
     # Copy newly generated codes to override the original
     cp -r sdk/ovirtsdk/* go-ovirt/
     cp -r sdk/examples go-ovirt/
 
     pushd go-ovirt
+    # Vendor the package dependencies
+    go mod vendor
     # Push only if there are changes
     if git status --porcelain 2>/dev/null | grep -E "^??|^M"
     then

--- a/sdk/ovirtsdk/go.mod
+++ b/sdk/ovirtsdk/go.mod
@@ -1,0 +1,5 @@
+module github.com/ovirt/go-ovirt
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/sdk/ovirtsdk/go.sum
+++ b/sdk/ovirtsdk/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### Description of the Change

Add `go.mod` and `go.sum` into the sdk generator to support package dependency management. For users do not use `go mod`, the vendor directory is auto-generated during TravisCI deploying phrase.
