### PR TITLE
Make build.py compatible with PY3

### DIFF
--- a/automation/build.py
+++ b/automation/build.py
@@ -43,7 +43,7 @@ def eval_command(args):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
     output, errors = proc.communicate()
     result = proc.wait()
-    return result, output
+    return result, output.decode(encoding='utf-8', errors='strict')
 
 
 def dec_version(version):


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### Description of the Change

Since `universal_newlines` is `False`  by default, the returned `output` is a `byte`  stream rather than `text` stream. So in PY3, we need to decode it into unicode string. This would make `build.py` be compatible with Python 3 to address the CI master hosts are switching to EL8/FC30.
