### PR TITLE
CI: Remove golang-github-stretchr-testify-devel rpm dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 before_install:
-  - go get github.com/stretchr/testify/assert
+  - eval "$(GIMME_GO_VERSION=1.12.x gimme)"
 
 install: true
 

--- a/automation/build.packages
+++ b/automation/build.packages
@@ -2,7 +2,6 @@ git
 java-1.8.0-openjdk-devel
 maven
 golang
-golang-github-stretchr-testify-devel
 libxslt
 python
 python-lxml

--- a/automation/build.packages.el7
+++ b/automation/build.packages.el7
@@ -2,6 +2,5 @@ git
 java-1.8.0-openjdk-devel
 maven
 golang
-golang-github-stretchr-testify-devel
 rpm-build
 rpmdevtools

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -109,11 +109,14 @@ limitations under the License.
               <goal>exec</goal>
             </goals>
             <configuration>
+              <workingDirectory>./ovirtsdk</workingDirectory>
               <executable>${go.command}</executable>
+              <environmentVariables>
+                <GOFLAGS>-mod=vendor</GOFLAGS>
+              </environmentVariables>
               <arguments>
                 <argument>build</argument>
                 <argument>-v</argument>
-                <argument>./ovirtsdk</argument>
               </arguments>
             </configuration>
           </execution>
@@ -127,11 +130,14 @@ limitations under the License.
             </goals>
             <configuration>
               <skip>${skipTests}</skip>
+              <workingDirectory>./ovirtsdk</workingDirectory>
+              <environmentVariables>
+                <GOFLAGS>-mod=vendor</GOFLAGS>
+              </environmentVariables>
               <executable>${go.command}</executable>
               <arguments>
                 <argument>test</argument>
                 <argument>-v</argument>
-                <argument>./ovirtsdk</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### Description of the Change

As the `golang-github-stretchr-testify-devel` rpm is no longer available in CentOS-8 ( as well as EPEL-8), and the source code of `stretchr/testify` has been already included in repository, I need to completely remove its dependency during CI stages since then. 
Another two changes in this PR:
1. In order to make the build be passed, this has some changes on `pom.xml`.
2. The default go version installed in travis ci node is `1.11.1` and it leads to a build failure due to issue https://github.com/golang/go/issues/30446 . This pr upgrades go to `1.12.x`.
