### PR TITLE
CI: Remove packaging on fc28

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,5 @@
 distros:
   - fc29
-  - fc28
   - el7
 release_branches:
   master: [ "ovirt-master", "ovirt-4.3" ]


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fedora 28 has been entering EOL since May 28, 2019, so this pr will stop the support of packaging on fc28.
