### PR TITLE
CI: Support for ppc64le and s390x archs

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,8 +1,10 @@
-distros:
-  - fc29
-  - fc30
-  - el7
-  - el8
+archs:
+  - x86_64:
+      distro: [el7, el8, fc29, fc30]
+  - ppc64le:
+      distro: [el7, el8]
+  - s390x:
+      distro: [fc29, fc30]
 release_branches:
   master: [ "ovirt-master", "ovirt-4.3" ]
   sdk_4.2: "ovirt-4.2"


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### Description of the Change
Inspired by https://github.com/oVirt/ovirt-engine-sdk/commit/4181e6b00eb2dd9e8800851f3ab679f1df4397b1 , use standard automation matrix to support for running CI upon `ppc64le` and `s390x` architectures
