### PR TITLE
modify add_cluster.go and add new examples

### DIFF
--- a/sdk/examples/add_fence_agent.go
+++ b/sdk/examples/add_fence_agent.go
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func addFenceAgent() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Find the host
+	hostsService := conn.SystemService().HostsService()
+	listResp, err := hostsService.List().Search("name=myhost").Send()
+	if err != nil {
+		fmt.Printf("Failed to search host list, reason: %v\n", err)
+		return
+	}
+	hostSlice, _ := listResp.Hosts()
+	host := hostSlice.Slice()[0]
+
+	// Find the service that manages the hosts
+	hostService := hostsService.HostService(host.MustId())
+
+	fenceAgentsService := hostService.FenceAgentsService()
+	// Use the "add" method to create a fence agents:
+	_, err = fenceAgentsService.Add().
+		Agent(
+			ovirtsdk4.NewAgentBuilder().
+				Address("1.2.3.4").
+				Type("ipmilan").
+				Username("myusername").
+				Password("mypassword").
+				OptionsOfAny(
+					ovirtsdk4.NewOptionBuilder().
+						Name("myname").
+						Value("myvalue").
+						MustBuild()).
+				Order(0).
+				MustBuild()).
+		Send()
+	if err != nil {
+		fmt.Printf("Failed to add fenceAgents, reason: %v\n", err)
+		return
+	}
+
+	// Prepare the update host object:
+	hostUpdate := &ovirtsdk4.Host{}
+
+	powerManagement, bool := host.PowerManagement()
+	kdumpEnabled := false
+	if bool && powerManagement != nil {
+		newPow := &ovirtsdk4.PowerManagement{}
+
+		// If power management isn't enabled, enable it. Note that
+		// power management can be enabled only if at least one fence
+		// agent exists for host:
+		enable, _ := powerManagement.Enabled()
+		if !enable {
+			newPow.SetEnabled(true)
+		}
+
+		//	If kdump isn't enabled, enable it. Note that kdump
+		//	can be enabled only if power management on the host
+		//	is enabled:
+		kdumpDetection, _ := powerManagement.KdumpDetection()
+		if !kdumpDetection {
+			kdumpEnabled = true
+			newPow.SetKdumpDetection(true)
+		}
+		hostUpdate.SetPowerManagement(newPow)
+	}
+
+	// Send the update request:
+	hostService.Update().Host(hostUpdate).Send()
+
+	// Note that after kdump integration is enabled the host must be
+	// reinstalled so the kdump will take effect. First we need to
+	// switch host to maintenance, because host must be in maintenance
+	// mode, for reinstall process:
+	if kdumpEnabled {
+		hostService.Deactivate().MustSend()
+		// Wait a bit so the host status is updated in API
+		time.Sleep(5 * time.Second)
+		for {
+			getHostResp, err := hostService.Get().Send()
+			if err != nil {
+				continue
+			}
+			if getHost, ok := getHostResp.Host(); ok {
+				if getHost.MustStatus() == ovirtsdk4.HOSTSTATUS_MAINTENANCE {
+					break
+				}
+			}
+			time.Sleep(2 * time.Second)
+		}
+
+		// Then we can execute the reinstall process
+		ssh := &ovirtsdk4.Ssh{}
+		ssh.SetAuthenticationMethod(ovirtsdk4.SSHAUTHENTICATIONMETHOD_PUBLICKEY)
+		hostService.Install().Ssh(ssh).Send()
+
+		// Wait a bit so the host status is updated in API
+		time.Sleep(5 * time.Second)
+		for {
+			getHostResp, err := hostService.Get().Send()
+			if err != nil {
+				continue
+			}
+			if getHost, ok := getHostResp.Host(); ok {
+				if getHost.MustStatus() == ovirtsdk4.HOSTSTATUS_MAINTENANCE {
+					break
+				}
+			}
+			time.Sleep(10 * time.Second)
+		}
+
+		// Activate the host after reinstall
+		hostService.Activate().MustSend()
+		time.Sleep(5 * time.Second)
+		for {
+			getHostResp, err := hostService.Get().Send()
+			if err != nil {
+				continue
+			}
+			if getHost, ok := getHostResp.Host(); ok {
+				if getHost.MustStatus() == ovirtsdk4.HOSTSTATUS_UP {
+					break
+				}
+			}
+			time.Sleep(2 * time.Second)
+		}
+
+	}
+}

--- a/sdk/examples/add_iscsi_data_storage_domain.go
+++ b/sdk/examples/add_iscsi_data_storage_domain.go
@@ -1,0 +1,140 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func addStorageDomain() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// use add method to create storageDomain
+	// Note that 'myhost' should be in a dc with version >= 4.1 for enabling
+	// the 'Discard After Delete' (DAD) parameter, since only from that
+	// version, the host returns the luns' discard related information.
+	storageDomainService := conn.SystemService().StorageDomainsService()
+
+	storageDomain, err := storageDomainService.Add().
+		StorageDomain(
+			ovirtsdk4.NewStorageDomainBuilder().
+				Name("1.2.3.4").
+				Description("My iSCSI With Discard After Delete").
+				Type(ovirtsdk4.STORAGEDOMAINTYPE_DATA).
+				DiscardAfterDelete(true).
+				DataCenter(
+					ovirtsdk4.NewDataCenterBuilder().
+						Name("mydc").
+						MustBuild()).
+				Host(
+					ovirtsdk4.NewHostBuilder().
+						Name("myhost").
+						MustBuild()).
+				StorageFormat(ovirtsdk4.STORAGEFORMAT_V4).
+				Storage(
+					ovirtsdk4.NewHostStorageBuilder().
+						Type(ovirtsdk4.STORAGETYPE_ISCSI).
+						OverrideLuns(true).
+						VolumeGroup(
+							ovirtsdk4.NewVolumeGroupBuilder().
+								LogicalUnitsOfAny(
+									ovirtsdk4.NewLogicalUnitBuilder().
+										Id("36001405e396b3d9c9a54284a51685f9a").
+										Address("192.168.201.3").
+										Port(int64(3260)).
+										Target("iqn.2014-07.org.ovirt:storage").
+										Username("username").
+										Password("password").
+										MustBuild()).
+								MustBuild()).
+						MustBuild()).
+				MustBuild()).
+		Send()
+	if err != nil {
+		fmt.Printf("Failed to add storageDomain, reason: %v\n", err)
+		return
+	}
+
+	// Locate the service that manages the data centers and use it to
+	// search for the data center:
+	dataCentersService := conn.SystemService().DataCentersService()
+	listResp, err := dataCentersService.List().Search("name=mydc").Send()
+	if err != nil {
+		fmt.Printf("Failed to search dataCenter list, reason: %v\n", err)
+		return
+	}
+	dataCentersSlice, _ := listResp.DataCenters()
+	dataCenter := dataCentersSlice.Slice()[0]
+
+	// Locate the service that manages the data center where we want to
+	// attach the storage domain:
+	dataCenterService := dataCentersService.DataCenterService(dataCenter.MustId())
+
+	// Locate the service that manages the storage domains that are attached
+	// to the data centers:
+	attachedSdsService := dataCenterService.StorageDomainsService()
+
+	// Use the "add" method of service that manages the attached storage
+	// domains to attach it.
+	// Note that attaching this SD to the dc will succeed only if the
+	// dc version is >= 4.1.
+	_, err = attachedSdsService.Add().
+		StorageDomain(
+			ovirtsdk4.NewStorageDomainBuilder().
+				Id(storageDomain.MustStorageDomain().MustId()).
+				MustBuild()).
+		Send()
+
+	// Wait till the storage domain is active:
+	attachedSdService := attachedSdsService.StorageDomainService(storageDomain.MustStorageDomain().MustId())
+	for {
+		getSdsResp, err := attachedSdService.Get().Send()
+		if err != nil {
+			continue
+		}
+		if getSd, ok := getSdsResp.StorageDomain(); ok {
+			if getSd.MustStatus() == ovirtsdk4.STORAGEDOMAINSTATUS_ACTIVE {
+				break
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/sdk/examples/add_openstack_image_provider.go
+++ b/sdk/examples/add_openstack_image_provider.go
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func addOpenstackImageProvider() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the list of OpenStack image providers (a.k.a. Glance providers)
+	// that match the name that we want to use:
+	openstackImageProvidersService := conn.SystemService().OpenstackImageProvidersService()
+
+	listResp, err := openstackImageProvidersService.List().Search("name=myglance").Send()
+	if err != nil {
+		fmt.Printf("Failed to search dataCenter list, reason: %v\n", err)
+		return
+	}
+	providersSlice, _ := listResp.Providers()
+
+	// There is no such provider, then add it
+	if len(providersSlice.Slice()) == 0 {
+		_, err = openstackImageProvidersService.Add().
+			Provider(
+				ovirtsdk4.NewOpenStackImageProviderBuilder().
+					Name("myglance").
+					Description("My Glance").
+					Url("http://glance.ovirt.org:9292").
+					RequiresAuthentication(false).
+					MustBuild()).
+			Send()
+	}
+
+	// Note that the provider that we are using in this example is public
+	// and doesn't require any authentication. If your provider requires
+	// authentication then you will need to specify additional security
+	// related attributes:
+	//_, err = openstackImageProvidersService.Add().
+	//	Provider(
+	//		ovirtsdk4.NewOpenStackImageProviderBuilder().
+	//			Name("myglance").
+	//			Description("My Glance").
+	//			Url("http://glance.ovirt.org:9292").
+	//			RequiresAuthentication(true).
+	//			AuthenticationUrl("http://mykeystone").
+	//			Username("myuser").
+	//			Password("mypassword").
+	//			TenantName("mytenant").
+	//			MustBuild()).
+	//	Send()
+
+}

--- a/sdk/examples/add_vm_pool.go
+++ b/sdk/examples/add_vm_pool.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func addVmPool() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,31 @@ func addCluster() {
 		}
 	}()
 
+	// Get the reference to the vm pools service:
+	vmPoolsService := conn.SystemService().VmPoolsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
+	// Use the "add" method to create a vmPool:
+	_, err = vmPoolsService.Add().
+		Pool(
+			ovirtsdk4.NewVmPoolBuilder().
+				Name("myVmPool").
+				Description("My vmPool").
+				Cluster(
+					ovirtsdk4.NewClusterBuilder().
+						Name("mycluster").
 						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
+				Template(
+					ovirtsdk4.NewTemplateBuilder().
+						Name("mytemplate").
 						MustBuild()).
+				Size(3).
+				PrestartedVms(1).
+				MaxUserVms(1).
+				Type(ovirtsdk4.VMPOOLTYPE_AUTOMATIC).
 				MustBuild()).
 		Send()
 	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
+		fmt.Printf("Failed to add vmPool, reason: %v\n", err)
 		return
 	}
 }

--- a/sdk/examples/assign_permission.go
+++ b/sdk/examples/assign_permission.go
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func assignPermission() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Locate the networks service and use it to find the network:
+	networksService := conn.SystemService().NetworksService()
+	networkListResp, err := networksService.List().Search("name=mynetwork").Send()
+	if err != nil {
+		fmt.Printf("Failed to search network list, reason: %v\n", err)
+		return
+	}
+	networksSlice, _ := networkListResp.Networks()
+	network := networksSlice.Slice()[0]
+
+	//Locate the users service and use it to find the user
+	usersService := conn.SystemService().UsersService()
+	userListResp, err := usersService.List().Search("userName=myuser@mydomain-authz").Send()
+	if err != nil {
+		fmt.Printf("Failed to search user list, reason: %v\n", err)
+		return
+	}
+	usersSlice, _ := userListResp.Users()
+	user := usersSlice.Slice()[0]
+
+	//Locate the role service and use it to find the role
+	rolesService := conn.SystemService().RolesService()
+	roleListResp, err := rolesService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search role list, reason: %v\n", err)
+		return
+	}
+	rolesSlice, _ := roleListResp.Roles()
+	role := &ovirtsdk4.Role{}
+	for _, da := range rolesSlice.Slice() {
+		if da.MustName() == "GlusterAdmin" {
+			role = da
+			break
+		}
+	}
+	if role == nil {
+		permitSlice := &ovirtsdk4.PermitSlice{}
+		permitSlice.SetSlice(genPermits([]string{"1", "1300"}))
+		role = ovirtsdk4.NewRoleBuilder().
+			Name("GlusterAdmin").
+			Description("My role").
+			Administrative(false).
+			Permits(permitSlice).
+			MustBuild()
+	}
+
+	// Locate the service that manages the permissions of the network
+	permissionsService := networksService.NetworkService(network.MustId()).PermissionsService()
+
+	// Use the "add" method to assign GlusterAdmin role to user on network
+	_, err = permissionsService.Add().
+		Permission(
+			ovirtsdk4.NewPermissionBuilder().
+				User(user).
+				Role(role).
+				MustBuild()).
+		Send()
+
+}

--- a/sdk/examples/assign_permission_to_vms.go
+++ b/sdk/examples/assign_permission_to_vms.go
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func assignPermissionToVm() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// This example will connect to the server and assign UserVmManager
+	// role to myuser1 on virtual machine name myvm1, myvm2 nad myvm3:
+	// List of virtual machine where user should have assigned permission:
+	myVms := []string{"myvm1", "myvm2", "myvm3"}
+
+	//Role which we want to assign to the user on the virtual machines:
+	roleName := "UserVmManager"
+
+	// Locate the users service and use it to find the user
+	usersService := conn.SystemService().UsersService()
+	userListResp, err := usersService.List().Search("userName=user2@internal-authz").Send()
+	if err != nil {
+		fmt.Printf("Failed to search user list, reason: %v\n", err)
+		return
+	}
+	usersSlice, _ := userListResp.Users()
+	user := usersSlice.Slice()[0]
+
+	// Locate the roles service and use it to find the role
+	role := &ovirtsdk4.Role{}
+	rolesService := conn.SystemService().RolesService()
+	roleListResp, err := rolesService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search role list, reason: %v\n", err)
+		return
+	}
+	rolesSlice, _ := roleListResp.Roles()
+	for _, da := range rolesSlice.Slice() {
+		if da.MustName() == roleName {
+			role = da
+			break
+		}
+	}
+	if role == nil {
+		permitSlice := &ovirtsdk4.PermitSlice{}
+		permitSlice.SetSlice(genPermits([]string{"1", "1300"}))
+		role = ovirtsdk4.NewRoleBuilder().
+			Name(roleName).
+			Description("My role").
+			Administrative(false).
+			Permits(permitSlice).
+			MustBuild()
+	}
+
+	for vmName := range myVms {
+		vmNamestr := fmt.Sprintf("name=%v", vmName)
+
+		// Locate the virtual machine service and use it to find the specific
+		// virtual machines:
+		vmsService := conn.SystemService().VmsService()
+		vmListResp, err := vmsService.List().Search(vmNamestr).Send()
+		if err != nil {
+			fmt.Printf("Failed to search vm list, reason: %v\n", err)
+			return
+		}
+		vmsSlice, _ := vmListResp.Vms()
+		vm := vmsSlice.Slice()[0]
+
+		// Locate the service that manages the permissions of the virtual machine:
+		permissionsService := vmsService.VmService(vm.MustId()).PermissionsService()
+
+		// Use the "add" method to assign UserVmManager role to user on virtual machine:
+		_, err = permissionsService.Add().
+			Permission(
+				ovirtsdk4.NewPermissionBuilder().
+					User(user).
+					Role(role).
+					MustBuild()).
+			Send()
+	}
+
+}

--- a/sdk/examples/asynchronous_inventory.go
+++ b/sdk/examples/asynchronous_inventory.go
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func asynchronousInventory() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Send requests for all the collections, but don't wait for the results. This
+	// way the requests will be sent simultaneously, using the multipl connections
+	systemService := conn.SystemService()
+	fmt.Printf("Requesting data...")
+	dcsListFuture, _ := systemService.DataCentersService().List().Send()
+	clustersListFuture, _ := systemService.ClustersService().List().Send()
+	sdsListFuture, _ := systemService.StorageDomainsService().List().Send()
+	networksListFuture, _ := systemService.NetworksService().List().Send()
+	hostsListFuture, _ := systemService.HostsService().List().Send()
+	vmsListFuture, _ := systemService.VmsService().List().Send()
+	disksListFuture, _ := systemService.DisksService().List().Send()
+
+	//# Wait for the results of the requests that we sent. The calls to the `wait`
+	//# method will perform all the work, for all the pending requests, and will
+	//# eventually return the requested data.
+	fmt.Printf("Waiting for data centers ...")
+	dcs := dcsListFuture.MustDataCenters()
+	fmt.Printf("Loaded %v data centers.", len(dcs.Slice()))
+
+	fmt.Printf("Waiting for clusters...")
+	clusters := clustersListFuture.MustClusters()
+	fmt.Printf("Loaded %v clusters.", len(clusters.Slice()))
+
+	fmt.Printf("Waiting for storage domains...")
+	sds := sdsListFuture.MustStorageDomains()
+	fmt.Printf("Loaded %v storage domains.", len(sds.Slice()))
+
+	fmt.Printf("Waiting for networks ...")
+	nets := networksListFuture.MustNetworks()
+	fmt.Printf("Loaded %v networks.", len(nets.Slice()))
+
+	fmt.Printf("Waiting for hosts ...")
+	hosts := hostsListFuture.MustHosts()
+	fmt.Printf("Loaded %v hosts.", len(hosts.Slice()))
+
+	fmt.Printf("Waiting for VMs ...")
+	vms := vmsListFuture.MustVms()
+	fmt.Printf("Loaded %v VMs.", len(vms.Slice()))
+
+	fmt.Printf("Waiting for disks ...")
+	disks := disksListFuture.MustDisks()
+	fmt.Printf("Loaded %v disks.", len(disks.Slice()))
+}

--- a/sdk/examples/change_host_cluster.go
+++ b/sdk/examples/change_host_cluster.go
@@ -1,0 +1,107 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func changeHostCluster() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the service that manages the hosts:
+	hostsService := conn.SystemService().HostsService()
+	listResp, err := hostsService.List().Search("name=myhost").Send()
+	if err != nil {
+		fmt.Printf("Failed to search host list, reason: %v\n", err)
+		return
+	}
+
+	// Find the host:
+	hostSlice, _ := listResp.Hosts()
+	host := hostSlice.Slice()[0]
+
+	// Get the reference to the service that manages the host
+	hostService := hostsService.HostService(host.MustId())
+
+	// Put host into maintenance:
+	if host.MustStatus() == ovirtsdk4.HOSTSTATUS_MAINTENANCE {
+		hostService.Deactivate().MustSend()
+
+		// Wait till the host is in maintenance:
+		for {
+			time.Sleep(5 * time.Second)
+			getHostResp, err := hostService.Get().Send()
+			if err != nil {
+				continue
+			}
+			if getHost, ok := getHostResp.Host(); ok {
+				if getHost.MustStatus() == ovirtsdk4.HOSTSTATUS_MAINTENANCE {
+					break
+				}
+			}
+		}
+	}
+
+	// Change the host cluster:
+	newCluster := &ovirtsdk4.Cluster{}
+	newCluster.SetName("mycluster")
+	host.SetCluster(newCluster)
+	hostService.Update().Host(host).Send()
+
+	//# Activate the host again:
+	hostService.Activate().MustSend()
+
+	// Wait till the host is in maintenance:
+	for {
+		time.Sleep(5 * time.Second)
+		getHostResp, err := hostService.Get().Send()
+		if err != nil {
+			continue
+		}
+		if getHost, ok := getHostResp.Host(); ok {
+			if getHost.MustStatus() == ovirtsdk4.HOSTSTATUS_UP {
+				break
+			}
+		}
+	}
+
+}

--- a/sdk/examples/data_center_maintenance.go
+++ b/sdk/examples/data_center_maintenance.go
@@ -1,0 +1,202 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func dataCenterMaintenance() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	// Creating the connection builder doesn't do anything, it just stores
+	// the parameter. To actually create the connection it is necessary to
+	// call the "build" method
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Find all clusters of the data center:
+	dataCentersService := conn.SystemService().DataCentersService()
+	dcsListResp, err := dataCentersService.List().Search("name=Default").Send()
+	if err != nil {
+		fmt.Printf("Failed to search dataCenter list, reason: %v\n", err)
+		return
+	}
+
+	// Retrieve the data center service:
+	dcSlice := dcsListResp.MustDataCenters()
+	dc := dcSlice.Slice()[0]
+	dcService := dataCentersService.DataCenterService(dc.MustId())
+
+	// Find all clusters of the data center:
+	clusters, err := dcService.ClustersService().List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search cluster list, reason: %v\n", err)
+		return
+	}
+	clusterSlice := clusters.MustClusters()
+	clusterIds := make(map[string]string, 0)
+	for _, cluster := range clusterSlice.Slice() {
+		clusterIds[cluster.MustId()] = cluster.MustId()
+	}
+
+	// 1. Shutdown all VMs of these clusters
+	fmt.Print("Shutting down all Virtual Machines")
+	isHostEngine := false
+	vmsService := conn.SystemService().VmsService()
+	vmsListResp, err := vmsService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search vm list, reason: %v\n", err)
+		return
+	}
+	vmSlice := vmsListResp.MustVms()
+	for _, vm := range vmSlice.Slice() {
+		if _, ok := clusterIds[vm.MustCluster().MustId()]; !ok {
+			continue
+		}
+
+		if vm.MustStatus() == ovirtsdk4.VMSTATUS_DOWN {
+			continue
+		}
+
+		vmService := vmsService.VmService(vm.MustId())
+
+		// Detect HostedEngine environments and switch it to HA Maintenance
+		if vm.MustName() == "HostedEngine" {
+			isHostEngine = true
+			vmService.Maintenance().MaintenanceEnabled(true).Send()
+			continue
+		}
+		vmService.Shutdown().Send()
+	}
+
+	// Wait for all VMs to reach down state
+	for {
+		vms := make([]string, 0)
+		ListResp, err := vmsService.List().Send()
+		if err != nil {
+			fmt.Printf("Failed to search vm list, reason: %v\n", err)
+			return
+		}
+		slice := ListResp.MustVms()
+		for _, vm := range slice.Slice() {
+			if vm.MustStatus() != ovirtsdk4.VMSTATUS_DOWN {
+				vms = append(vms, vm.MustId())
+			}
+		}
+
+		if (len(vms) == 1 && isHostEngine) || vms != nil {
+			break
+		}
+
+		time.Sleep(10 * time.Second)
+
+	}
+
+	// 2. Switch all storage to maintenance
+	sdsService := dcService.StorageDomainsService()
+	sdsListResp, err := sdsService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search sd list, reason: %v\n", err)
+		return
+	}
+	sdSlice := sdsListResp.MustStorageDomains()
+	for _, sd := range sdSlice.Slice() {
+		if sd.MustName() == "hosted_storage" {
+			continue
+		}
+		if sd.MustStatus() != ovirtsdk4.STORAGEDOMAINSTATUS_ACTIVE &&
+			sd.MustStatus() != ovirtsdk4.STORAGEDOMAINSTATUS_MIXED {
+			continue
+		}
+
+		sdService := sdsService.StorageDomainService(sd.MustId())
+		sdService.Deactivate().Send()
+	}
+
+	// Wait for all SDs to reach maintenance state
+	fmt.Printf("Setting maintenance mode on Storage Domains")
+	for {
+		sds := make([]string, 0)
+		ListResp, err := sdsService.List().Send()
+		if err != nil {
+			fmt.Printf("Failed to search sd list, reason: %v\n", err)
+			return
+		}
+		slice := ListResp.MustStorageDomains()
+		for _, sd := range slice.Slice() {
+			if sd.MustStatus() != ovirtsdk4.STORAGEDOMAINSTATUS_MAINTENANCE {
+				sds = append(sds, sd.MustId())
+			}
+		}
+
+		if (len(sds) == 1 && isHostEngine) || sds != nil {
+			break
+		}
+
+		fmt.Printf("waiting for %v SDs to reach Maintenance state...", len(sds))
+		time.Sleep(10 * time.Second)
+	}
+
+	// 3. Switch all hosts to maintenance state
+	hostsService := conn.SystemService().HostsService()
+	hostsListResp, err := hostsService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search host list, reason: %v\n", err)
+		return
+	}
+	hostSlice := hostsListResp.MustHosts()
+	for _, host := range hostSlice.Slice() {
+		if _, ok := clusterIds[host.MustCluster().MustId()]; !ok {
+			continue
+		}
+		if host.MustStatus() != ovirtsdk4.HOSTSTATUS_UP {
+			continue
+		}
+		// Is running HE, SPM role may switch to this host
+		if isHostEngine && host.MustSummary().MustTotal() > 0 {
+			continue
+		}
+
+		hostService := hostsService.HostService(host.MustId())
+		hostService.Deactivate().Send()
+
+	}
+
+}

--- a/sdk/examples/deactivate_disk_attachment.go
+++ b/sdk/examples/deactivate_disk_attachment.go
@@ -1,0 +1,113 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func deactivateDiskAttachment() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Locate the virtual machines service and use it to find the virtual machine
+	vmsService := conn.SystemService().VmsService()
+	vmsResp, err := vmsService.List().Search("name=myvm").Send()
+	if err != nil {
+		fmt.Printf("Failed to search vm list, reason: %v\n", err)
+		return
+	}
+	vmSlice, _ := vmsResp.Vms()
+	vm := vmSlice.Slice()[0]
+
+	// Get disks service and find the disk we want:
+	disksService := conn.SystemService().DisksService()
+	disksResp, err := disksService.List().Search("name=mydisk").Send()
+	if err != nil {
+		fmt.Printf("Failed to search disk list, reason: %v\n", err)
+		return
+	}
+	diskSlice, _ := disksResp.Disks()
+	disk := diskSlice.Slice()[0]
+
+	// Locate the service that manages the disk attachments of the virtual machine
+	dasService := vmsService.VmService(vm.MustId()).DiskAttachmentsService()
+	diskAttachments, err := dasService.List().Send()
+
+	diskAttachmentInVm := &ovirtsdk4.DiskAttachment{}
+
+	for _, diskAttachment := range diskAttachments.MustAttachments().Slice() {
+		if diskAttachment.MustDisk().MustId() == disk.MustId() {
+			diskAttachmentInVm = diskAttachment
+			break
+		}
+	}
+
+	// Deactivate the disk we found
+	// or print an error if there is no such disk attached:
+	if diskAttachmentInVm != nil {
+		// Locate the service that manages the disk attachment that we found
+		// in the previous step:
+		diskAttachmentService := dasService.AttachmentService(diskAttachmentInVm.MustId())
+
+		// Deactivate the disk attachment
+		diskAttachmentService.Update().
+			DiskAttachment(
+				ovirtsdk4.NewDiskAttachmentBuilder().
+					Active(false).
+					MustBuild()).
+			Send()
+
+		// Wait till the disk attachment not active:
+		for {
+			time.Sleep(5 * time.Second)
+			diskAttachmentResp, _ := diskAttachmentService.Get().Send()
+			if diskAttachment, ok := diskAttachmentResp.Attachment(); ok {
+				if !diskAttachment.MustActive() {
+					break
+				}
+			}
+		}
+
+	} else {
+		fmt.Printf("There's no disk attachment for %v.", disk.MustName())
+	}
+
+}

--- a/sdk/examples/disable_compression.go
+++ b/sdk/examples/disable_compression.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func disableCompression() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,13 @@ func addCluster() {
 		}
 	}()
 
+	// By disabling compression you can debug the communication,
+	// as communication will be visible in plain text and won't
+	// be raw compressed. Note that compression is automatically
+	// disabled in case user pass debug parameter set to `true`.
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
-	}
+	// Get some data:
+	api := conn.SystemService().Get().MustSend().MustApi()
+	version := api.MustProductInfo().MustVersion().MustFullVersion()
+	fmt.Printf("Use FullVersion() function to get the fullVersion %v", version)
 }

--- a/sdk/examples/download_vm_ovf.go
+++ b/sdk/examples/download_vm_ovf.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ package examples
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func downloadVmOvf() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +48,30 @@ func addCluster() {
 		}
 	}()
 
+	// Get a reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
+	//# Look up fot the vm by name:
+	vmResp, err := vmsService.List().
+		Search("name=myvm").
+		AllContent(true).
 		Send()
 	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
+		fmt.Printf("Failed to search vm list, reason: %v\n", err)
 		return
 	}
+	vmSlice, _ := vmResp.Vms()
+	vm := vmSlice.Slice()[0]
+
+	ovfFileName := fmt.Sprintf("%v.ovf", vm.MustId())
+
+	file, err := os.Open(ovfFileName)
+	if err != nil {
+		fmt.Printf("Failed to open the file, reason: %v\n", err)
+		return
+	}
+	defer file.Close()
+
+	file.WriteString(vm.MustInitialization().MustConfiguration().MustData())
+
 }

--- a/sdk/examples/export_template_as_ova.go
+++ b/sdk/examples/export_template_as_ova.go
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func exportTemplateAsOva() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get a reference to the template service:
+	templatesService := conn.SystemService().TemplatesService()
+
+	//# Look up fot the template by name:
+	templateResp, err := templatesService.List().Search("name=mytemplate").Send()
+	if err != nil {
+		fmt.Printf("Failed to search template list, reason: %v\n", err)
+		return
+	}
+	templateSlice, _ := templateResp.Templates()
+	template := templateSlice.Slice()[0]
+
+	templateService := templatesService.TemplateService(template.MustId())
+
+	// Find the host
+	hostsService := conn.SystemService().HostsService()
+	hostResp, err := hostsService.List().Search("name=myhost").Send()
+	if err != nil {
+		fmt.Printf("Failed to search host list, reason: %v\n", err)
+		return
+	}
+	hostSlice, _ := hostResp.Hosts()
+	host := hostSlice.Slice()[0]
+
+	// Export the virtual machine template. Note that the 'filename'
+	// parameter is optional, and only required if you want to specify
+	// a name for the  generated OVA file that is different from
+	// <template_name>.ova.
+	// Note that this operation is only available since version 4.2.3
+	// of the engine and since version 4.2.5 of the SDK.
+	templateService.ExportToPathOnHost().
+		Host(host).
+		Directory("/tmp").
+		Filename("mytemplate2.ova").
+		Send()
+
+}

--- a/sdk/examples/export_vm_as_ova.go
+++ b/sdk/examples/export_vm_as_ova.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func exportVmAsOva() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,34 @@ func addCluster() {
 		}
 	}()
 
+	// Get a reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
+	//# Look up fot the vm by name:
+	vmResp, err := vmsService.List().Search("name=myvm").Send()
 	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
+		fmt.Printf("Failed to search vm list, reason: %v\n", err)
 		return
 	}
+	vmSlice, _ := vmResp.Vms()
+	vm := vmSlice.Slice()[0]
+
+	vmService := vmsService.VmService(vm.MustId())
+
+	// Find the host
+	hostsService := conn.SystemService().HostsService()
+	hostResp, err := hostsService.List().Search("name=myhost").Send()
+	if err != nil {
+		fmt.Printf("Failed to search host list, reason: %v\n", err)
+		return
+	}
+	hostSlice, _ := hostResp.Hosts()
+	host := hostSlice.Slice()[0]
+
+	vmService.ExportToPathOnHost().
+		Host(host).
+		Directory("/tmp").
+		Filename("myvm2.ova").
+		Send()
+
 }

--- a/sdk/examples/extend_disk.go
+++ b/sdk/examples/extend_disk.go
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func extendDisk() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get a reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
+
+	//# Look up fot the vm by name:
+	vmResp, err := vmsService.List().Search("name=myvm").Send()
+	if err != nil {
+		fmt.Printf("Failed to search vm list, reason: %v\n", err)
+		return
+	}
+	vmSlice, _ := vmResp.Vms()
+	vm := vmSlice.Slice()[0]
+
+	diskAttachmentsService := vmsService.VmService(vm.MustId()).DiskAttachmentsService()
+
+	// Use the "add" method of the disk attachments service to add the disk.
+	// Note that the size of the disk, the `provisioned_size` attribute, is
+	// specified in bytes, so to create a disk of 10 GiB the value should
+	// be 10 * 2^30.
+	diskAttachment, err := diskAttachmentsService.Add().
+		Attachment(
+			ovirtsdk4.NewDiskAttachmentBuilder().
+				Disk(
+					ovirtsdk4.NewDiskBuilder().
+						Name("mydisk").
+						Description("my disk").
+						Format(ovirtsdk4.DISKFORMAT_COW).
+						ProvisionedSize(int64(10) * int64(1<<30)).
+						StorageDomainsOfAny(
+							ovirtsdk4.NewStorageDomainBuilder().
+								Name("bs-scsi-012").
+								MustBuild()).
+						MustBuild()).
+				Interface(ovirtsdk4.DISKINTERFACE_VIRTIO).
+				Bootable(false).
+				Active(true).
+				MustBuild()).
+		Send()
+
+	if err != nil {
+		fmt.Printf("Failed to add disk attachment, reason: %v\n", err)
+		return
+	}
+
+	// Wait till the disk is ok
+	disksService := conn.SystemService().DisksService()
+	diskService := disksService.DiskService(diskAttachment.MustAttachment().MustId())
+	for {
+		time.Sleep(5 * time.Second)
+		diskResp, _ := diskService.Get().Send()
+		if disk, ok := diskResp.Disk(); ok {
+			if disk.MustStatus() == ovirtsdk4.DISKSTATUS_OK {
+				break
+			}
+		}
+	}
+
+}

--- a/sdk/examples/get_display_ticket.go
+++ b/sdk/examples/get_display_ticket.go
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func getDisplayTicket() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get a reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
+
+	//# Look up fot the vm by name:
+	vmResp, err := vmsService.List().Search("name=myvm").Send()
+	if err != nil {
+		fmt.Printf("Failed to search vm list, reason: %v\n", err)
+		return
+	}
+	vmSlice, _ := vmResp.Vms()
+	vm := vmSlice.Slice()[0]
+
+	consolesService := vmsService.VmService(vm.MustId()).GraphicsConsolesService()
+
+	// The method that lists the graphics consoles doesn't support search, so in
+	// order to find the console corresponding to the access protocol that we are
+	// interested on (SPICE in this example) we need to get all of them and filter
+	// explicitly. In addition the `current` parameter must be `True`, as otherwise
+	// you will *not* get important values like the `address` and `port` where the
+	// console is available.
+	consolesResp, err := consolesService.List().Send()
+	if err != nil {
+		fmt.Printf("Failed to search console list, reason: %v\n", err)
+		return
+	}
+	consoleSlice, _ := consolesResp.Consoles()
+	newConsole := &ovirtsdk4.GraphicsConsole{}
+	for _, console := range consoleSlice.Slice() {
+		if console.MustProtocol() == ovirtsdk4.GRAPHICSTYPE_SPICE {
+			newConsole = console
+		}
+	}
+
+	// Find the service that manages the graphics console that was selected in the
+	// previous step:
+	consoleService := consolesService.ConsoleService(newConsole.MustId())
+
+	// Request the ticket. The virtual machine must be up and running, as it
+	// doesn't make sense to get a console ticket for a virtual machine that
+	// is down. If you try that, the request will fail.
+	ticket := consoleService.Ticket().MustSend().MustTicket()
+
+	// Print the details needed to connect to the console (the ticket value is the
+	// password):
+	fmt.Printf("address: %v\n", newConsole.MustAddress())
+	fmt.Printf("port: %v\n", newConsole.Port())
+	fmt.Printf("tls_port: %v\n", newConsole.TlsPort())
+	fmt.Printf("password: %v\n", ticket.MustValue())
+
+}

--- a/sdk/examples/import_vm_from_vmware.go
+++ b/sdk/examples/import_vm_from_vmware.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func importVmFromVmware() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,29 @@ func addCluster() {
 		}
 	}()
 
+	// Get the reference to the service that manages import of external
+	//virtual machines:
+	importsService := conn.SystemService().ExternalVmImportsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
+	// Initiate the import of VM 'myvm' from VMware:
+	importsService.Add().
+		Import(
+			ovirtsdk4.NewExternalVmImportBuilder().
+				Name("myvm").
+				Provider(ovirtsdk4.EXTERNALVMPROVIDERTYPE_VMWARE).
+				Username("wmware_user").
+				Password("wmware123").
+				Url("vpx://wmware_user@vcenter-host/DataCenter/Cluster/esxi-host?no_verify=1").
+				Cluster(
+					ovirtsdk4.NewClusterBuilder().
+						Name("mycluster").
 						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
+				StorageDomain(
+					ovirtsdk4.NewStorageDomainBuilder().
+						Name("mydata").
 						MustBuild()).
+				Sparse(true).
 				MustBuild()).
 		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
-	}
+
 }

--- a/sdk/examples/list_tags.go
+++ b/sdk/examples/list_tags.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func listTags() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,24 @@ func addCluster() {
 		}
 	}()
 
-
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
+	tagsService := conn.SystemService().TagsService()
+	resp, err := tagsService.List().Send()
 	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
+		fmt.Printf("Failed to get tag list, reason: %v\n", err)
 		return
 	}
+
+	if tagSlice, ok := resp.Tags(); ok {
+		for _, tag := range tagSlice.Slice() {
+			fmt.Printf("Tag: (")
+			if tagName, ok := tag.Name(); ok {
+				fmt.Printf(" name: %v", tagName)
+			}
+			if tagDesc, ok := tag.Description(); ok {
+				fmt.Printf(" desc: %v", tagDesc)
+			}
+			fmt.Println(")")
+		}
+	}
+
 }

--- a/sdk/examples/page_vms.go
+++ b/sdk/examples/page_vms.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func pageVms() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,29 @@ func addCluster() {
 		}
 	}()
 
+	// Get the reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
+	// List the vm page by page:
+	size := int64(1)
+	index := int64(1)
+	for {
+		pageIndex := fmt.Sprintf("page %v", index)
+		vmsResp, err := vmsService.List().Search(pageIndex).Max(size).Send()
+		if err != nil {
+			fmt.Printf("Failed to get vm list, reason: %v\n", err)
+			return
+		}
+		if len(vmsResp.MustVms().Slice()) == 0 {
+			break
+		}
 
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
+		for _, vm := range vmsResp.MustVms().Slice() {
+			fmt.Printf("Vm name: %v\n", vm.MustName())
+		}
+
+		index += int64(1)
+		fmt.Printf("Index: %v\n", index)
 	}
+
 }

--- a/sdk/examples/poll_events.go
+++ b/sdk/examples/poll_events.go
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func pollEvents() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Find the service that manages the collection of events:
+	eventsService := conn.SystemService().EventsService()
+
+	/* If there is no index stored yet, then retrieve the last event and
+	start with it. Events are ordered by index, ascending, and 'max=1'
+	requests just one event, so we will get the last event.*/
+	if readIndex() == 0 {
+		events := eventsService.List().Max(1).MustSend()
+		if len(events.MustEvents().Slice()) > 0 {
+			event := events.MustEvents().Slice()[0]
+			fmt.Printf("%v - %v", event.MustId(), event.MustDescription())
+
+			eventId, err := strconv.ParseInt(event.MustId(), 10, 64)
+			fmt.Printf("Failed to parse the string, reason: %v\n", err)
+			writeIndex(eventId)
+		}
+	}
+
+	/* Do a loop to retrieve events, starting always with the last index, and
+	waiting a bit before repeating. Note the use of the 'from' parameter
+	to specify that we want to get events newer than the last index that
+	we already processed. Note also that we don't use the 'max' parameter
+	here because we want to get all the pending events.*/
+	for {
+		time.Sleep(5 * time.Second)
+		eventResp, err := eventsService.List().From(readIndex()).Send()
+		if err != nil {
+			fmt.Printf("Failed to get event list, reason: %v\n", err)
+			return
+		}
+		for _, event := range eventResp.MustEvents().Slice() {
+			fmt.Printf("%v - %v", event.MustId(), event.MustDescription())
+			eventId, err := strconv.ParseInt(event.MustId(), 10, 64)
+			fmt.Printf("Failed to parse the string, reason: %v\n", err)
+			writeIndex(eventId)
+		}
+	}
+
+}
+
+func readIndex() (b int64) {
+	_, err := os.Stat("index.txt")
+	if err == nil {
+		// File exist
+		file, err := os.Open("index.txt")
+		defer file.Close()
+		if err != nil {
+			fmt.Printf("Failed to open the file, reason:%v\n", err)
+			return 0
+		}
+		readBuf := make([]byte, 1024)
+		for {
+			n, err := file.Read(readBuf)
+			if n == 0 {
+				break
+			}
+			fmt.Println(int64(n), err)
+			return int64(n)
+		}
+
+	}
+	return 0
+}
+
+func writeIndex(data int64) {
+	bytebuf := bytes.NewBuffer([]byte{})
+	binary.Write(bytebuf, binary.BigEndian, data)
+	//将指定内容写入到文件中
+	err := ioutil.WriteFile("index.txt", bytebuf.Bytes(), 0666)
+	if err != nil {
+		fmt.Printf("ioutil WriteFile error: %v\n ", err)
+	}
+}

--- a/sdk/examples/print_vm_mac_duplicates.go
+++ b/sdk/examples/print_vm_mac_duplicates.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func printVmMacDup() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,34 @@ func addCluster() {
 		}
 	}()
 
+	// Get the reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
+	vmsResp, err := vmsService.List().Send()
 	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
+		fmt.Printf("Failed to get vm list, reason: %v\n", err)
 		return
+	}
+
+	vmNics := make(map[string]string, 0)
+	// Iterate via all virtual machines and print if they have duplicated MAC
+	// address with any other virtual machine in the system:
+	for _, vm := range vmsResp.MustVms().Slice() {
+		fmt.Printf("Vm name: %v\n", vm.MustName())
+		vmService := vmsService.VmService(vm.MustId())
+		nicsResp, err := vmService.NicsService().List().Send()
+		if err != nil {
+			fmt.Printf("Failed to get nic list, reason: %v\n", err)
+		}
+		for _, nic := range nicsResp.MustNics().Slice() {
+			if _, exists := vmNics[nic.MustMac().MustAddress()]; exists {
+				println("key exists in map")
+				fmt.Printf("[%v]: MAC address '%v' is used by following virtual machine already: %v",
+					nic.MustName(), nic.MustMac().MustAddress(), vmNics)
+			} else {
+				vmNics[nic.MustMac().MustAddress()] = vm.MustName()
+			}
+
+		}
 	}
 }

--- a/sdk/examples/remove_numa_nodes_from_vm.go
+++ b/sdk/examples/remove_numa_nodes_from_vm.go
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func removeNumaNodesFromVm() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
+
+	// Retrieve the description of the virtual machine:
+	vmsResp, err := vmsService.List().Search("name=myvm").Send()
+	if err != nil {
+		fmt.Printf("Failed to get vm list, reason: %v\n", err)
+		return
+	}
+	vm := vmsResp.MustVms().Slice()[0]
+
+	//In order to update the virtual machine we need a reference to the service
+	// the manages it:
+	vmService := vmsService.VmService(vm.MustId())
+
+	// Get the reference to the numa nodes service of the virtual machine:
+	vmNodesService := vmService.NumaNodesService()
+
+	// For each numa node of the virtual machine we call the remove method
+	// to remove the numa node. Note that we must remove the numa nodes from
+	// highest numa node index to lowest numa node index:
+	vmNodeResp, err := vmNodesService.List().Send()
+	vmNodes := vmNodeResp.MustNodes().Slice()
+	sort.Slice(vmNodes, func(i, j int) bool {
+		return vmNodes[i].MustIndex() > vmNodes[j].MustIndex() // reverse=True
+	})
+
+	for _, vmNode := range vmNodes {
+		fmt.Printf("Removing node with id %v\n", vmNode.MustId())
+		vmNodeService := vmNodesService.NodeService(vmNode.MustId())
+		vmNodeService.Remove().Send()
+	}
+
+}

--- a/sdk/examples/set_vm_serial_number.go
+++ b/sdk/examples/set_vm_serial_number.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func setVmSerialNumber() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,31 @@ func addCluster() {
 		}
 	}()
 
+	// Get the reference to the vm service:
+	vmsService := conn.SystemService().VmsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
+	// Retrieve the description of the virtual machine:
+	vmsResp, err := vmsService.List().Search("name=myvm").Send()
+	if err != nil {
+		fmt.Printf("Failed to get vm list, reason: %v\n", err)
+		return
+	}
+	vm := vmsResp.MustVms().Slice()[0]
 
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
+	//In order to update the virtual machine we need a reference to the service
+	// the manages it:
+	vmService := vmsService.VmService(vm.MustId())
+
+	// Use the "update" method to set a serial number policy and value:
+	vmService.Update().
+		Vm(
+			ovirtsdk4.NewVmBuilder().
+				SerialNumber(
+					ovirtsdk4.NewSerialNumberBuilder().
+						Policy(ovirtsdk4.SERIALNUMBERPOLICY_CUSTOM).
+						Value("myserial").
 						MustBuild()).
 				MustBuild()).
 		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
-	}
+
 }

--- a/sdk/examples/show_summary.go
+++ b/sdk/examples/show_summary.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func showSummary() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,12 @@ func addCluster() {
 		}
 	}()
 
+	// Get API information from the root service:
+	api := conn.SystemService().Get().MustSend().MustApi()
+	fmt.Printf("Version: %v\n", api.MustProductInfo().MustVersion())
+	fmt.Printf("Hosts: %v\n", api.MustSummary().MustHosts().MustTotal())
+	fmt.Printf("StorageDomain: %v\n", api.MustSummary().MustStorageDomains().MustTotal())
+	fmt.Printf("Users: %v\n", api.MustSummary().MustUsers().MustTotal())
+	fmt.Printf("Vms: %v\n", api.MustSummary().MustUsers().MustTotal())
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
-	}
 }

--- a/sdk/examples/start_vm_with_boot_devices.go
+++ b/sdk/examples/start_vm_with_boot_devices.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func startVmWithBootDevices() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,47 @@ func addCluster() {
 		}
 	}()
 
+	// Get the reference to the "vms" service:
+	vmsService := conn.SystemService().VmsService()
 
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
+	// Find the virtual machine:
+	vmsResp, err := vmsService.List().Search("name=myvm").Send()
+	if err != nil {
+		fmt.Printf("Failed to get vm list, reason: %v\n", err)
+		return
+	}
 
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
+	// Locate the service that manages the virtual machine, as that is where
+	// the action methods are defined:
+	vm := vmsResp.MustVms().Slice()[0]
+	vmService := vmsService.VmService(vm.MustId())
+
+	// Call the "start" method of the service to start it with
+	// additional properties in a run once configuration
+	vmService.Start().
+		Vm(
+			ovirtsdk4.NewVmBuilder().
+				Os(
+					ovirtsdk4.NewOperatingSystemBuilder().
+						Boot(
+							ovirtsdk4.NewBootBuilder().
+								DevicesOfAny(
+									ovirtsdk4.BOOTDEVICE_NETWORK,
+									ovirtsdk4.BOOTDEVICE_CDROM).
+								MustBuild()).
 						MustBuild()).
 				MustBuild()).
 		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
+
+	// Wait till the virtual machine is up:
+	for {
+		time.Sleep(5 * time.Second)
+		vmResp, _ := vmService.Get().Send()
+		if vm, ok := vmResp.Vm(); ok {
+			if vm.MustStatus() == ovirtsdk4.VMSTATUS_UP {
+				break
+			}
+		}
 	}
+
 }

--- a/sdk/examples/test_connection.go
+++ b/sdk/examples/test_connection.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 huihui0311 <huihui.fu@cs2c.com.cn>.
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 )
 
-func addCluster() {
+func testConnection() {
 	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
 
 	conn, err := ovirtsdk4.NewConnectionBuilder().
@@ -47,29 +47,13 @@ func addCluster() {
 		}
 	}()
 
-
-	// Get the reference to the clusters service:
-	clustersService := conn.SystemService().ClustersService()
-
-	// Use the "add" method to create a cluster:
-	_, err = clustersService.Add().
-		Cluster(
-			ovirtsdk4.NewClusterBuilder().
-				Name("mycluster").
-				Description("My cluster").
-				Cpu(
-					ovirtsdk4.NewCpuBuilder().
-						Architecture(ovirtsdk4.ARCHITECTURE_X86_64).
-						Type("Intel Conroe Family").
-						MustBuild()).
-				DataCenter(
-					ovirtsdk4.NewDataCenterBuilder().
-						Name("mydc").
-						MustBuild()).
-				MustBuild()).
-		Send()
-	if err != nil {
-		fmt.Printf("Failed to add cluster, reason: %v\n", err)
-		return
+	// Call the test method to check the connectivity with the server. If
+	// connectivity works this method will return "nil". If there is any
+	// connectivy problem it will either return "error":
+	if conn.Test() == nil {
+		fmt.Sprintf("Connection works.")
+	} else {
+		fmt.Sprintf("Connection doesn't work.")
 	}
+
 }

--- a/sdk/examples/upgrade_host.go
+++ b/sdk/examples/upgrade_host.go
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2017 huihui <huihui.fu@csc2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func upgradeHosts() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the service that manages the hosts
+	hostsService := conn.SystemService().HostsService()
+
+	// Get the reference to the service that manages the host
+	eventsService := conn.SystemService().EventsService()
+
+	// Find the host
+	host := hostsService.List().
+		Search("name=myhost").
+		MustSend().
+		MustHosts().
+		Slice()[0]
+
+	// Get the reference to the service that manages the fencing agents used by the host that we found in the
+	// previous step
+	hostService := hostsService.HostService(host.MustId())
+
+	// Check if the host has available update, if not run check for
+	// upgrade action:
+	if !host.MustUpdateAvailable() {
+		// Run the check for upgrade action:
+		hostService.UpgradeCheck().Send()
+
+		// Wait until event with id 839 or 887 occur, which means
+		// that check for upgrade action failed.
+		// Or wait until event with id 885 occured, which means
+		// that check for upgrade action succeed.
+		lastEvent := eventsService.List().Max(int64(1)).MustSend().
+			MustEvents().Slice()[0]
+		timeOut := int64(180)
+		lastEventId, _ := strconv.ParseInt(lastEvent.MustId(), 10, 64)
+		hostName := fmt.Sprintf("host.name=%v", host.MustName())
+
+		for {
+			if timeOut > 0 {
+				eventResp := eventsService.List().
+					From(lastEventId).
+					Search(hostName).
+					MustSend()
+
+				for _, event := range eventResp.MustEvents().Slice() {
+					if (event.MustCode() == 839) || (event.MustCode() == 887) {
+						fmt.Printf("Check for upgrade failed.")
+						break
+					}
+					if (event.MustCode() == 839) || (event.MustCode() == 887) {
+						fmt.Printf("Check for upgrade done.")
+						break
+					}
+				}
+				time.Sleep(2 * time.Second)
+				timeOut -= 2
+			} else {
+				break
+			}
+		}
+	}
+
+	// Refresh the host object and run the upgrade action
+	// if host has available updates:
+	getResp, err := hostService.Get().Send()
+	if err != nil {
+		fmt.Printf("Faild to get host, reason: %v\n", err)
+	}
+	// Check if the host is OK
+	if host, ok := getResp.Host(); ok {
+		if host.MustUpdateAvailable() {
+			hostService.Upgrade().Send()
+		}
+	}
+
+}

--- a/sdk/examples/vm_backup.go
+++ b/sdk/examples/vm_backup.go
@@ -1,0 +1,241 @@
+//
+// Copyright (c) 2020 huihui <huihui.fu@cs2c.com.cn>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package examples
+
+import (
+	"fmt"
+	uuid "github.com/satori/go.uuid"
+	"os"
+	"time"
+
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func vmBackup() {
+	inputRawURL := "https://10.1.111.229/ovirt-engine/api"
+
+	conn, err := ovirtsdk4.NewConnectionBuilder().
+		URL(inputRawURL).
+		Username("admin@internal").
+		Password("qwer1234").
+		Insecure(true).
+		Compress(true).
+		Timeout(time.Second * 10).
+		Build()
+	if err != nil {
+		fmt.Printf("Make connection failed, reason: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	// To use `Must` methods, you should recover it if panics
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Printf("Panics occurs, try the non-Must methods to find the reason")
+		}
+	}()
+
+	// Get the reference to the service that we will use to send events to
+	// the audit log:
+	eventsService := conn.SystemService().EventsService()
+
+	// Get the reference to the "vms" service:
+	vmsService := conn.SystemService().VmsService()
+
+	// Find the virtual machine:
+	vmsResp, err := vmsService.List().Search("name=myvm").
+		AllContent(true).Send()
+	if err != nil {
+		fmt.Printf("Failed to get data vm list, reason: %v\n", err)
+		return
+	}
+
+	// Locate the service that manages the virtual machine, as that is where
+	// the action methods are defined:
+	dataVm := vmsResp.MustVms().Slice()[0]
+	fmt.Printf("Find the data vm %v, the id is %v\n",
+		dataVm.MustName(), dataVm.MustId())
+
+	//Find the virtual machine were we will attach the disks in order to do
+	// the backup:
+	agentVmsResp, err := vmsService.List().Search("name=myagent").Send()
+	if err != nil {
+		fmt.Printf("Failed to get agent vm list, reason: %v\n", err)
+		return
+	}
+
+	agentVm := agentVmsResp.MustVms().Slice()[0]
+	fmt.Printf("Find the agent vm %v, the id is %v\n",
+		agentVm.MustName(), agentVm.MustId())
+
+	// Find the services that manage the data and agent virtual machines:
+	dataVmService := vmsService.VmService(dataVm.MustId())
+	agentVmService := vmsService.VmService(agentVm.MustId())
+
+	//Create an unique description for the snapshot, so that it is easier
+	// for the administrator to identify this snapshot as a temporary one
+	// created just for backup purposes:
+	snapDesc := fmt.Sprintf("%v-backup-%v", dataVm.MustName(), uuid.NewV4())
+
+	// Send an external event to indicate to the administrator that the
+	// backup of the virtual machine is starting. Note that the description
+	// of the event contains the name of the virtual machine and the name of
+	// the temporary snapshot, this way, if something fails, the administrator
+	// will know what snapshot was used and remove it manually.
+	eventId := time.Now().Unix()
+	desc := fmt.Sprintf("Backup of virtual machine %v using snapshot %v is starting",
+		dataVm.MustName(), snapDesc)
+
+	eventsService.Add().
+		Event(
+			ovirtsdk4.NewEventBuilder().
+				Vm(
+					ovirtsdk4.NewVmBuilder().
+						Id(dataVm.MustId()).MustBuild()).
+				Origin("mybackup").
+				Severity(ovirtsdk4.LOGSEVERITY_NORMAL).
+				CustomId(eventId).
+				Description(desc).
+				MustBuild()).
+		Send()
+
+	eventId += 1
+	// Save the OVF to a file, so that we can use to restore the virtual
+	// machine later. The name of the file is the name of the virtual
+	// machine, followed by a dash and the identifier of the virtual machine,
+	// to make it unique:
+	ovfData := dataVm.MustInitialization().MustConfiguration().MustData()
+	ovfFile := fmt.Sprintf("%v-%v.ovf", dataVm.MustName(), dataVm.MustId())
+
+	file, err := os.OpenFile(ovfFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		fmt.Println("open file failed, reason:", err)
+		return
+	}
+	defer file.Close()
+
+	file.WriteString(ovfData)
+
+	// Send the request to create the snapshot. Note that this will return
+	// before the snapshot is completely created, so we will later need to
+	// wait till the snapshot is completely created.
+	// The snapshot will not include memory. Change to True the parameter
+	// persist_memorystate to get it (in that case the VM will be paused for a while).
+	snapsService := dataVmService.SnapshotsService()
+	snap, err := snapsService.Add().
+		Snapshot(
+			ovirtsdk4.NewSnapshotBuilder().
+				Description(snapDesc).
+				PersistMemorystate(false).
+				MustBuild()).
+		Send()
+
+	fmt.Printf("Sent request to create snapshot %v, the id is %v",
+		snap.MustSnapshot().MustDescription(), snap.MustSnapshot().MustId())
+
+	// Poll and wait till the status of the snapshot is 'ok', which means
+	// that it is completely created:
+	snapService := snapsService.SnapshotService(snap.MustSnapshot().MustId())
+	for {
+		time.Sleep(1 * time.Second)
+		snap := snapService.Get().MustSend().MustSnapshot()
+		if snap.MustSnapshotStatus() == ovirtsdk4.SNAPSHOTSTATUS_OK {
+			break
+		}
+		fmt.Printf("Waiting till the snapshot is created, the satus is %v nes",
+			snap.MustSnapshotStatus())
+	}
+
+	// Retrieve the descriptions of the disks of the snapshot:
+	snapDisksService := snapService.DisksService()
+	snapDisks := snapDisksService.List().MustSend()
+
+	// Attach all the disks of the snapshot to the agent virtual machine, and
+	// save the resulting disk attachments in a list so that we can later
+	// detach them easily:
+	attachmentsService := agentVmService.DiskAttachmentsService()
+	attachments := make([]*ovirtsdk4.DiskAttachment, 0)
+	for _, snapDisk := range snapDisks.MustDisks().Slice() {
+		attachment := attachmentsService.Add().
+			Attachment(
+				ovirtsdk4.NewDiskAttachmentBuilder().
+					Disk(
+						ovirtsdk4.NewDiskBuilder().
+							Id(snapDisk.MustId()).
+							Snapshot(
+								ovirtsdk4.NewSnapshotBuilder().
+									Id(snap.MustSnapshot().MustId()).
+									MustBuild()).
+							MustBuild()).
+					Active(true).
+					Bootable(false).
+					Interface(ovirtsdk4.DISKINTERFACE_VIRTIO).
+					MustBuild()).
+			MustSend()
+		attachments = append(attachments, attachment.MustAttachment())
+		fmt.Println("Attached disk %v to the agent vm.",
+			attachment.MustAttachment().MustId())
+	}
+
+	// Now the disks are attached to the virtual agent virtual machine, we
+	// can then ask that virtual machine to perform the backup. Doing that
+	// requires a mechanism to talk to the backup software that runs inside the
+	// agent virtual machine. That is outside of the scope of the SDK. But if
+	// the guest agent is installed in the virtual machine then we can
+	// provide useful information, like the identifiers of the disks that have
+	// just been attached.
+	for _, attachment := range attachments {
+		if attachment.MustLogicalName() != "" {
+			fmt.Printf("The logical name for disk %v is %v",
+				attachment.MustDisk().MustId(), attachment.MustLogicalName())
+		} else {
+			fmt.Printf("The logical name for disk %v is not available. Is the guest agent installed?",
+				attachment.MustDisk().MustId())
+		}
+	}
+	//Insert here the code to contact the backup agent and do the actual
+	// backup ...
+	fmt.Printf("Doing the actual backup ...")
+
+	// Detach the disks from the agent virtual machine:
+	for _, attachment := range attachments {
+		attachmentService := attachmentsService.AttachmentService(attachment.MustId())
+		attachmentService.Remove().Send()
+		fmt.Printf("Detached disk %v to from the agent virtual machine.",
+			attachment.MustDisk().MustId())
+	}
+
+	snapService.Remove().Send()
+	fmt.Printf("Remove the snapshot %v.", snap.MustSnapshot().MustDescription())
+
+	// Send an external event to indicate to the administrator that the
+	// backup of the virtual machine is completed:
+	eventsService.Add().
+		Event(
+			ovirtsdk4.NewEventBuilder().
+				Vm(
+					ovirtsdk4.NewVmBuilder().
+						Id(dataVm.MustId()).MustBuild()).
+				Origin("mybackup").
+				Severity(ovirtsdk4.LOGSEVERITY_NORMAL).
+				CustomId(eventId).
+				Description(desc).
+				MustBuild()).
+		Send()
+
+	eventId += 1
+}


### PR DESCRIPTION
### Description of the Change

- Correct a syntax error in  add_cluster.go

- Add new examples: 
add_fence_agent.go
add_iscsi_data_storage_domain.go
add_openstack_image_provider.go
add_role.go
add_vm_pool.go
assign_permission.go
assign_permission_to_vms.go
asynchronous_inventory.go
change_host_cluster.go
data_center_maintenance.go
list_tags.go
deactivate_disk_attachment.go
disable_compression.go
download_vm_ovf.go
export_template.go
export_template_as_ova.go
export_vm_as_ova.go
extend_disk.go
get_display_ticket.go
get_vm_ip.go
import_vm_from_ova.go
import_vm_from_vmware.go
page_vms.go
poll_events.go
print_vm_mac_duplicates.go
remove_numa_nodes_from_vm.go
set_vm_serial_number.go
show_summary.go
sparsify_disk.go
start_vm_with_boot_devices.go
test_connection.go
upgrade_host.go
vm_backup.go