### PR TITLE
Fix error handling in case token request errors

### DIFF
--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -94,6 +94,9 @@ func (c *Connection) testToken() (int, error) {
 		return 0, err
 	}
 	res, err := c.client.Do(options)
+	if err != nil {
+		return 0, err
+	}
 	defer res.Body.Close()
 
 	return res.StatusCode, err


### PR DESCRIPTION
Fixing a defer pitfal, where the err isn't returned immediatly and the 
   req.Body.Close() is called on defer, where actionly the Body == nil.

   Signed-off-by: Roy Golan <rgolan@redhat.com>