### PR TITLE
Update automation.yaml

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,10 +1,11 @@
 archs:
   - x86_64:
-      distro: [el7, el8, fc29, fc30]
+      distro: [el7, el8, fc30]
   - ppc64le:
       distro: [el7, el8]
   - s390x:
-      distro: [fc29, fc30]
+      distro: fc30
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3" ]
+  master: "ovirt-master"
+  sdk_4.3: "ovirt-4.3"
   sdk_4.2: "ovirt-4.2"


### PR DESCRIPTION
Update automation for sdk_4.3 branch

### Requirements

* allow to run CI automation on sdk_4.3

### Description of the Change

Updated the automation.yaml file for building sdk 4.3 and push builds to the oVirt 4.3 pipeline

### Alternate Designs

No alternate design

### Benefits

Allow to build for oVirt 4.3

### Possible Drawbacks

N/A

### Verification Process

Check CI really builds from this branch and then push to 4.3 pipeline

### Applicable Issues

Related to issue #201
