### PR TITLE
Update automation.yaml

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,10 +1,11 @@
 archs:
   - x86_64:
-      distro: [el7, el8, fc29, fc30]
+      distro: [el8, fc30]
   - ppc64le:
-      distro: [el7, el8]
+      distro: [el8]
   - s390x:
-      distro: [fc29, fc30]
+      distro: fc30
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3" ]
+  master: "ovirt-master"
+  sdk_4.3: "ovirt-4.3"
   sdk_4.2: "ovirt-4.2"


### PR DESCRIPTION
### Requirements

* Update automation.yaml for not pushing sdk 4.4 to oVirt 4.3 pipeline
* Limit builds to supported platforms on 4.4

### Description of the Change

Update automation configuration for building master only for oVirt 4.4

### Alternate Designs

N/A

### Benefits

Avoid to get 4.4 builds in 4.3 repos

### Possible Drawbacks

N/A

### Verification Process

Checking CI results

### Applicable Issues

Related to issue #201 
