### PR TITLE
Check if response is not nil

### DIFF
--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -151,6 +151,10 @@ func (c *Connection) FollowLink(object Href) (interface{}, error) {
 		requestCaller = serviceValue.MethodByName("Get").Call([]reflect.Value{})[0]
 	}
 	callerResponse := requestCaller.MethodByName("Send").Call([]reflect.Value{})[0]
+	if callerResponse.IsNil() {
+		return nil, errors.New("Could not get response")
+	}
+
 	// Get the method index, which is not the Must version
 	methodIndex := 0
 	callerResponseType := callerResponse.Type()


### PR DESCRIPTION
### Description of the Change
Before executing the relevant FollowLink method, make sure the response we got from the engine is not nil, otherwise the response object will be nil and panic.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
This is a bug fix. If ovirt-engine is not accessible before a FollowLink call, it will panic because the response object will be nil.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
This can be reproduced easily by terminating the ovirt-engine process right before the FollowLink call, an example stack trace would look like this:
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xca3385]

goroutine 1 [running]:
github.com/ovirt/go-ovirt.(*DiskServiceGetResponse).Disk(0x0, 0x0, 0x0)
        /home/bzlotnik/Development/go/src/github.com/ovirt/go-ovirt/services.go:119416 +0x5
reflect.Value.call(0x102ce60, 0xc0001cb468, 0x293, 0x114312e, 0x4, 0xc0001c5c58, 0x0, 0x0, 0x0, 0x0, ...)
        /usr/lib/golang/src/reflect/value.go:460 +0x8ab
reflect.Value.Call(0x102ce60, 0xc0001cb468, 0x293, 0xc0001c5c58, 0x0, 0x0, 0x1, 0xc, 0x0)
        /usr/lib/golang/src/reflect/value.go:321 +0xb4
github.com/ovirt/go-ovirt.(*Connection).FollowLink(0xc00015a000, 0x128ba60, 0xc0001351e0, 0x1, 0x1, 0x14, 0x0)
        /home/bzlotnik/Development/go/src/github.com/ovirt/go-ovirt/connection.go:172 +0x7d2
main.main()
        ...
```

I used this snippet[1] to reproduce, with my patch the result is:
```
sleep before follow
follow failed: Failed to get response
```
https://gist.github.com/bennyz/d5b5f5112aa4b1ea27b6dc41791a8fab

### Applicable Issues

<!-- Enter any applicable Issues here -->
