### PR TITLE
Prepare for release 4.4.2

### DIFF
--- a/automation/build.packages
+++ b/automation/build.packages
@@ -1,5 +1,5 @@
 git
-java-1.8.0-openjdk-devel
+java-11-openjdk-devel
 maven
 golang
 libxslt

--- a/automation/build.packages.el8
+++ b/automation/build.packages.el8
@@ -1,5 +1,5 @@
 git
-java-1.8.0-openjdk-devel
+java-11-openjdk-devel
 maven
 golang
 rpm-build

--- a/automation/build.packages.fc30
+++ b/automation/build.packages.fc30
@@ -1,5 +1,5 @@
 git
-java-1.8.0-openjdk-devel
+java-11-openjdk-devel
 maven
 golang
 libxslt

--- a/automation/build.py
+++ b/automation/build.py
@@ -33,8 +33,13 @@ SETTINGS = """
 
 
 def run_command(args):
+    env = dict(os.environ)
+    env["JAVA_HOME"] = "/usr/lib/jvm/java-11"
     print("Running command %s ..." % args)
-    proc = subprocess.Popen(args)
+    proc = subprocess.Popen(
+       args=args,
+       env=env,
+    )
     return proc.wait()
 
 

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.4.2-SNAPSHOT</version>
+    <version>4.4.2</version>
   </parent>
 
   <artifactId>go-sdk-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
-    <metamodel.version>1.3.1</metamodel.version>
-    <model.version>4.4.14</model.version>
+    <metamodel.version>1.3.3</metamodel.version>
+    <model.version>4.4.19</model.version>
 
     <!-- The command used to start Go: -->
     <go.command>go</go.command>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <groupId>org.ovirt.engine.api</groupId>
   <artifactId>go-sdk-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.4.2-SNAPSHOT</version>
+  <version>4.4.2</version>
 
   <name>oVirt Go SDK Parent</name>
 
@@ -55,7 +55,7 @@ limitations under the License.
     <connection>scm:git:git://github.com/oVirt/ovirt-engine-sdk-go.git</connection>
     <developerConnection>scm:git:git://github.com/oVirt/ovirt-engine-sdk-go.git</developerConnection>
     <url>git://github.com/oVirt/ovirt-engine-sdk-go.git</url>
-    <tag>HEAD</tag>
+    <tag>4.4.2</tag>
   </scm>
 
   <properties>
@@ -82,13 +82,14 @@ limitations under the License.
     <pluginManagement>
       <plugins>
 
+        <!-- Make sure we use Java 11. -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.8.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
 

--- a/sdk/CHANGES.adoc
+++ b/sdk/CHANGES.adoc
@@ -2,6 +2,40 @@
 
 This document describes the relevant changes between releases of the SDK.
 
+== 4.4.2 / Oct 13 2020
+
+Update to model 4.4.19 and metamodel 1.3.3
+
+New features:
+
+* Add add_cluster.go and add new examples
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/196[GitHub-196]
+
+* Tries the connection token aquired in `Test()` method
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/197[GitHub-197]
+
+* Add CACert attribute to connection
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/203[GitHub-203]
+
+* Add new example set_vm_comment.go for sdk
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/212[Github-212]
+
+
+Bug fixes:
+
+* Fix error handling in case token request errors
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/204[GitHub-204]
+
+* Networks parsing problem
+  https://bugzilla.redhat.com/1841556[1841556].
+
+* Fix show_summary and add check_OCP_support
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/211[Github-211]
+
+* Check if follow link response is not nil
+  https://github.com/oVirt/ovirt-engine-sdk-go/pull/215[Github-215]
+
+
 == 4.4.1 / Jan 31 2020
 
 Bug fixes:

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>go-sdk-parent</artifactId>
-    <version>4.4.2-SNAPSHOT</version>
+    <version>4.4.2</version>
   </parent>
 
   <artifactId>go-sdk</artifactId>
@@ -78,7 +78,7 @@ limitations under the License.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>3.0.0</version>
         <executions>
 
           <!-- Run the code generator: -->


### PR DESCRIPTION
### Description of the Change

Fixes #214. 

This PR is going to bump to model 4.4.19, metamodel 1.3.3 and use Java 11 for build.

This will also make release `4.4.2`, which includes the plenty of features and bug fixes. Please see `sdk/CHANGES.adoc` for details. 
