### PR TITLE
Bump api-model to 4.4.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
     <metamodel.version>1.3.4</metamodel.version>
-    <model.version>4.4.25</model.version>
+    <model.version>4.4.28</model.version>
 
     <!-- The command used to start Go: -->
     <go.command>go</go.command>


### PR DESCRIPTION
### Description of the Change

This PR is going to bump api-model to 4.4.28, which is the latest version and it's included in oVirt 4.4.6.


Signed-off-by: imjoey <majunjie@apache.org>