### PR TITLE
bump API model to 4.4.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
     <metamodel.version>1.3.4</metamodel.version>
-    <model.version>4.4.28</model.version>
+    <model.version>4.4.29</model.version>
 
     <!-- The command used to start Go: -->
     <go.command>go</go.command>


### PR DESCRIPTION
Bumping API model due to a blocker in RHV 4.4.6

Signed-off-by: Eli Mesika <emesika@redhat.com>

