### PR TITLE
Added error handling to SSO failures

### DIFF
--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -298,6 +298,16 @@ func (c *Connection) getSsoResponse(inputURL *url.URL, parameters map[string]str
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode == 401 {
+		// Don't bother decoding, this will be a HTML message
+		return nil, &AuthError{
+			baseError: baseError{
+				Msg: fmt.Sprintf("authentication failed (response was: %v)", string(body)),
+			},
+		}
+	}
+
 	var jsonObj ssoResponseJSON
 	err = json.Unmarshal(body, &jsonObj)
 	if err != nil {


### PR DESCRIPTION
### Description of the Change

This change adds proper error handling for 401 failures when authenticating against the oVirt engine. Since the 401 error is accompanied by a HTML error message the client library would give a hard to understand error to the user. This PR fixes that by returning a clear structured auth error with a clear error message when a 401 error happens.

### Alternate Designs

The oVirt engine could be changed to return a proper JSON for auth errors.

### Benefits

Trivial.

### Possible Drawbacks

It is a workaround for the oVirt engine behavior.

### Verification Process

Verified by including it in [go-ovirt-client](https://github.com/ovirt/go-ovirt-client) and running the appropriate fault identification test.

### Applicable Issues

Numerous customer BZ's in relation to OCP on RHV.