### PR TITLE
Better HTTP error message

### DIFF
--- a/sdk/ovirtsdk/connection.go
+++ b/sdk/ovirtsdk/connection.go
@@ -211,7 +211,7 @@ func (c *Connection) revokeAccessToken() error {
 
 	if ssoResp.SsoError != "" {
 		return &AuthError{
-			baseError{
+			baseError: baseError{
 				Msg: fmt.Sprintf("Error during SSO token revoke %s : %s", ssoResp.SsoErrorCode, ssoResp.SsoError),
 			},
 		}

--- a/sdk/ovirtsdk/error.go
+++ b/sdk/ovirtsdk/error.go
@@ -4,20 +4,22 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
 type baseError struct {
+	// Code contains the HTTP status code that caused this error.
 	Code int
-	Msg  string
+	// Msg contains the text message that should be printed to the user.
+	Msg string
 }
 
+// Error returns the error string.
 func (b *baseError) Error() string {
 	return b.Msg
 }
 
-// AuthError indicates that an authentiation or authorization
+// AuthError indicates that an authentication or authorization
 // problem happened, like incorrect user name, incorrect password, or
 // missing permissions.
 type AuthError struct {
@@ -29,12 +31,26 @@ type NotFoundError struct {
 	baseError
 }
 
-// CheckFault procoesses error parsing and returns it back
-func CheckFault(response *http.Response) error {
-	resBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response (%w)", err)
-	}
+// ResponseParseError indicates that the response from the oVirt Engine could not be parsed.
+type ResponseParseError struct {
+	baseError
+
+	cause error
+	body  []byte
+}
+
+// Unwrap returns the root cause of this error.
+func (r *ResponseParseError) Unwrap() error {
+	return r.cause
+}
+
+// Body returns the HTTP response body that caused the parse error.
+func (r *ResponseParseError) Body() []byte {
+	return r.body
+}
+
+// CheckFault takes a failed HTTP response (non-200) and extracts the fault from it.
+func CheckFault(resBytes []byte, response *http.Response) error {
 	// Process empty response body
 	if len(resBytes) == 0 {
 		return BuildError(response, nil)
@@ -43,11 +59,18 @@ func CheckFault(response *http.Response) error {
 	reader := NewXMLReader(resBytes)
 	fault, err := XMLFaultReadOne(reader, nil, "")
 	if err != nil {
-		// If the XML is not a <fault>, just return nil
-		if err, ok := err.(XMLTagNotMatchError); ok {
-			return err
+		return &ResponseParseError{
+			baseError{
+				Code: response.StatusCode,
+				Msg: fmt.Sprintf(
+					"failed to parse oVirt Engine fault response: %s (%v)",
+					resBytes,
+					err,
+				),
+			},
+			err,
+			resBytes,
 		}
-		return err
 	}
 	if fault != nil || response.StatusCode >= 400 {
 		return BuildError(response, fault)
@@ -56,22 +79,30 @@ func CheckFault(response *http.Response) error {
 }
 
 // CheckAction checks if response contains an Action instance
-func CheckAction(response *http.Response) (*Action, error) {
-	resBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response (%w)", err)
-	}
+func CheckAction(resBytes []byte, response *http.Response) (*Action, error) {
 	// Process empty response body
 	if len(resBytes) == 0 {
 		return nil, BuildError(response, nil)
 	}
+	var tagNotMatchError XMLTagNotMatchError
 
 	faultreader := NewXMLReader(resBytes)
 	fault, err := XMLFaultReadOne(faultreader, nil, "")
 	if err != nil {
 		// If the tag mismatches, return the err
-		if _, ok := err.(XMLTagNotMatchError); !ok {
-			return nil, err
+		if !errors.As(err, &tagNotMatchError) {
+			return nil, &ResponseParseError{
+				baseError{
+					Code: response.StatusCode,
+					Msg: fmt.Sprintf(
+						"failed to parse oVirt Engine response: %s (%v)",
+						resBytes,
+						err,
+					),
+				},
+				err,
+				resBytes,
+			}
 		}
 	}
 	if fault != nil {
@@ -82,7 +113,7 @@ func CheckAction(response *http.Response) (*Action, error) {
 	action, err := XMLActionReadOne(actionreader, nil, "")
 	if err != nil {
 		// If the tag mismatches, return the err
-		if _, ok := err.(XMLTagNotMatchError); !ok {
+		if errors.As(err, &tagNotMatchError) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Description of the Change

This change adds better handling for HTTP 500 / non-XML errors (e.g. HTML error messages). It refactors the HTTP body reading and provides the response as a slice instead of having it read in several places, possibly resulting in multiple attempts to read the body. The resulting error is given a type (`ResponseParseError`), which can be used to identify errors when the response is not an XML response.

### Alternate Designs

Refactor the oVirt Engine.

### Benefits

Proper error handling.

### Possible Drawbacks

None.

### Verification Process

The full [go-ovirt-client](https://github.com/oVirt/go-ovirt-client) test suite has been ran against this change successfully.

### Applicable Issues

None.
