### PR TITLE
Fix Apache 2.0 license text

### DIFF
--- a/sdk/LICENSE.txt
+++ b/sdk/LICENSE.txt
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,3 +174,28 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
The Go package documentation website at go.pkg.dev only contains packages that contain a known OSI approved license. The document included in the oVirt SDK is missing the appendix, causing a large enough difference percentage to mismatch.

![image](https://github.com/user-attachments/assets/a4fb76e4-5962-4add-a7fa-762cedee493a)

The `LICENSE` file in this repository already contains the correct license text (including the appendix), the `sdk/LICENSE.txt` file that is copied to the SDK does not.

* https://pkg.go.dev/github.com/ovirt/go-ovirt
* https://pkg.go.dev/license-policy
* https://pkg.go.dev/github.com/google/licensecheck